### PR TITLE
레시피 및 질병 검색 Elasticsearch 적용

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -9,7 +9,6 @@
         <outputRelativeToContentRoot value="true" />
         <processorPath useClasspath="false">
           <entry name="$MAVEN_REPOSITORY$/org/projectlombok/lombok/1.18.42/lombok-1.18.42.jar" />
-          <entry name="$MAVEN_REPOSITORY$/org/projectlombok/lombok/1.18.42/lombok-1.18.42.jar" />
         </processorPath>
         <module name="healthforu" />
         <module name="health-for-u-server" />

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,10 @@
 			<version>0.12.6</version>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-elasticsearch</artifactId>
+		</dependency>
 
 	</dependencies>
 

--- a/src/main/java/com/healthforu/config/DiseaseDataInitializer.java
+++ b/src/main/java/com/healthforu/config/DiseaseDataInitializer.java
@@ -1,0 +1,4 @@
+package com.healthforu.config;
+
+public class DiseaseDataInitializer {
+}

--- a/src/main/java/com/healthforu/config/DiseaseDataInitializer.java
+++ b/src/main/java/com/healthforu/config/DiseaseDataInitializer.java
@@ -1,4 +1,42 @@
 package com.healthforu.config;
 
-public class DiseaseDataInitializer {
+import com.healthforu.disease.domain.Disease;
+import com.healthforu.disease.domain.DiseaseDocument;
+import com.healthforu.disease.repository.DiseaseRepository;
+import com.healthforu.disease.repository.elasticsearch.DiseaseSearchRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DiseaseDataInitializer implements CommandLineRunner {
+
+    private final DiseaseRepository mongodiseaseRepository;
+    private final DiseaseSearchRepository diseaseSearchRepository;
+
+
+    @Override
+    public void run(String... args) throws Exception {
+        if(diseaseSearchRepository.count() > 0){
+            log.info("Elasticsearch에 이미 데이터가 존재합니다. 마이그레이션을 건너뜁니다.");
+            return;
+        }
+
+        log.info("MongoDB에서 Elasticsearch로 데이터 마이그레이션을 시작합니다.");
+
+        List<Disease> allDiseases = mongodiseaseRepository.findAll();
+
+        List<DiseaseDocument> documents = allDiseases.stream()
+                .map(DiseaseDocument::from)
+                .toList();
+
+        diseaseSearchRepository.saveAll(documents);
+
+    }
 }

--- a/src/main/java/com/healthforu/config/ElasticsearchConfig.java
+++ b/src/main/java/com/healthforu/config/ElasticsearchConfig.java
@@ -1,0 +1,18 @@
+package com.healthforu.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+
+@Configuration
+@EnableElasticsearchRepositories(basePackages = "com.healthforu")
+public class ElasticsearchConfig extends ElasticsearchConfiguration {
+
+    @Override
+    public ClientConfiguration clientConfiguration() {
+        return ClientConfiguration.builder()
+                .connectedTo("localhost:9200") // 테스트 완료 후 배포 전 수정 필요
+                .build();
+    }
+}

--- a/src/main/java/com/healthforu/config/ElasticsearchConfig.java
+++ b/src/main/java/com/healthforu/config/ElasticsearchConfig.java
@@ -1,5 +1,6 @@
 package com.healthforu.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
 import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
@@ -9,10 +10,16 @@ import org.springframework.data.elasticsearch.repository.config.EnableElasticsea
 @EnableElasticsearchRepositories(basePackages = "com.healthforu")
 public class ElasticsearchConfig extends ElasticsearchConfiguration {
 
+    @Value("${spring.elasticsearch.uris:http://localhost:9200}")
+    private String esUri;
+
     @Override
     public ClientConfiguration clientConfiguration() {
+        // http:// 또는 https:// 가 포함되어 있다면 제거
+        String hostAndPort = esUri.replace("http://", "").replace("https://", "");
+
         return ClientConfiguration.builder()
-                .connectedTo("localhost:9200") // 테스트 완료 후 배포 전 수정 필요
+                .connectedTo(hostAndPort)
                 .build();
     }
 }

--- a/src/main/java/com/healthforu/config/MongoDataInitializer.java
+++ b/src/main/java/com/healthforu/config/MongoDataInitializer.java
@@ -1,0 +1,123 @@
+package com.healthforu.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.healthforu.recipe.domain.Recipe;
+import com.healthforu.recipe.dto.RawRecipeDto;
+import com.healthforu.recipe.repository.RecipeRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * 식품안전나라 공공 API를 통해 레시피 데이터를 수집하고
+ * MongoDB에 최초 한 번만 벌크 삽입하는 서비스 클래스입니다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MongoDataInitializer {
+
+    private final RecipeRepository recipeRepository;
+    private final RestTemplate restTemplate;
+    private final Environment env;
+
+    /**
+     * 외부 API로부터 데이터를 수집하여 엔티티로 변환 후
+     * 데이터베이스에 일괄 저장하는 메인 프로세스를 실행합니다.
+     */
+    @Transactional
+    public void importRecipesFromExternalApi() {
+        List<RawRecipeDto> externalRecipes = fetchRecipesFromApi();
+
+        if (externalRecipes.isEmpty()) {
+            return;
+        }
+
+        List<Recipe> recipesToInsert = externalRecipes.stream()
+                .map(this::convertToEntity)
+                .collect(Collectors.toList());
+
+        recipeRepository.bulkInsertRecipes(recipesToInsert);
+    }
+
+    /**
+     * 수집된 원본 DTO(RawRecipeDto)를 도메인 엔티티(Recipe)로 변환합니다.
+     * @param r 원본 데이터 DTO
+     * @return 가공된 Recipe 엔티티
+     */
+    private Recipe convertToEntity(RawRecipeDto r) {
+        return Recipe.builder()
+                .recipeName(r.getRCP_NM())
+                .recipeThumbnail(r.getATT_FILE_NO_MK())
+                .ingredients(r.getRCP_PARTS_DTLS())
+                .manualSteps(extractStructuredManual(r))
+                .build();
+    }
+
+    /**
+     * 비정형화된 API 원본 텍스트에서 조리 단계별 설명과 이미지를 추출합니다.
+     * 정규식을 사용하여 텍스트 끝의 불필요한 문자를 정제합니다.
+     * @param recipe 원본 데이터 DTO
+     * @return 정제된 조리 단계 리스트 (ManualStep)
+     */
+    private List<Recipe.ManualStep> extractStructuredManual(RawRecipeDto recipe) {
+        List<Recipe.ManualStep> steps = new ArrayList<>();
+        Pattern cleanupPattern = Pattern.compile("(?<=\\.)[a-z]$", Pattern.CASE_INSENSITIVE);
+
+        for (int step = 1; step <= 20; step++) {
+            String stepText = recipe.getManualTextByStep(step);
+            String stepImg = recipe.getManualImgByStep(step);
+
+            if (stepText == null || stepText.trim().isEmpty()) break;
+
+            String cleanedText = cleanupPattern.matcher(stepText.trim()).replaceAll("").trim();
+
+            steps.add(new Recipe.ManualStep(step, cleanedText, stepImg != null ? stepImg.trim() : ""));
+        }
+        return steps;
+    }
+
+    /**
+     * 식품안전나라 Open API를 호출하여 원본 레시피 데이터를 가져옵니다.
+     * 환경 설정 파일에서 인증 정보를 읽어오며, Jackson을 사용하여 결과를 DTO로 매핑합니다.
+     * 추후, api 통신만을 담당하는 Client를 만들 예정입니다.
+     * @return 수집된 RawRecipeDto 리스트
+     */
+    private List<RawRecipeDto> fetchRecipesFromApi(){
+        String authKey = env.getProperty("AUTH_KEY");
+        String serviceId = env.getProperty("SERVICE_ID");
+        String dataType = env.getProperty("DATA_TYPE");
+        Integer startIdx = 1;
+        Integer endIdx = 100;
+        String uri = String.format("http://openapi.foodsafetykorea.go.kr/api/%s/%s/%s/%d/%d",
+                authKey, serviceId, dataType, startIdx, endIdx);
+        try{
+            Map<String, Object> response = restTemplate.getForObject(uri, Map.class);
+
+            if(response != null && response.containsKey("COOKRCP01")){
+                Map<String, Object> cookRecipe = (Map<String, Object>) response.get("COOKRCP01");
+                List<Map<String, Object>> rowList = (List<Map<String, Object>>) cookRecipe.get("row");
+
+                ObjectMapper mapper = new ObjectMapper();
+                return rowList.stream()
+                        .map(row -> mapper.convertValue(row, RawRecipeDto.class))
+                        .collect(Collectors.toList());
+            }
+        } catch(Exception e){
+            log.error("레시피 API 호출 중 오류 발생 : ", e.getMessage());
+        }
+
+        return new ArrayList<>();
+
+
+    }
+}

--- a/src/main/java/com/healthforu/config/RecipeDataInitializer.java
+++ b/src/main/java/com/healthforu/config/RecipeDataInitializer.java
@@ -1,123 +1,40 @@
 package com.healthforu.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.healthforu.recipe.domain.Recipe;
-import com.healthforu.recipe.dto.RawRecipeDto;
+import com.healthforu.recipe.domain.RecipeDocument;
 import com.healthforu.recipe.repository.RecipeRepository;
+import com.healthforu.recipe.repository.elasticsearch.RecipeSearchRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.env.Environment;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-/**
- * 식품안전나라 공공 API를 통해 레시피 데이터를 수집하고
- * MongoDB에 최초 한 번만 벌크 삽입하는 서비스 클래스입니다.
- */
 @Slf4j
-@Service
+@Component
 @RequiredArgsConstructor
-public class RecipeDataInitializer {
+public class RecipeDataInitializer implements CommandLineRunner {
 
-    private final RecipeRepository recipeRepository;
-    private final RestTemplate restTemplate;
-    private final Environment env;
+    private final RecipeRepository mongoRecipeRepository;
+    private final RecipeSearchRepository esRecipeSearchRepository;
 
-    /**
-     * 외부 API로부터 데이터를 수집하여 엔티티로 변환 후
-     * 데이터베이스에 일괄 저장하는 메인 프로세스를 실행합니다.
-     */
-    @Transactional
-    public void importRecipesFromExternalApi() {
-        List<RawRecipeDto> externalRecipes = fetchRecipesFromApi();
-
-        if (externalRecipes.isEmpty()) {
+    @Override
+    public void run(String... args) throws Exception {
+        if(esRecipeSearchRepository.count() > 0){
+            log.info("Elasticsearch에 이미 데이터가 존재합니다. 마이그레이션을 건너뜁니다.");
             return;
         }
 
-        List<Recipe> recipesToInsert = externalRecipes.stream()
-                .map(this::convertToEntity)
+        log.info("MongoDB에서 Elasticsearch로 데이터 마이그레이션을 시작합니다.");
+
+        List<Recipe> allRecipes = mongoRecipeRepository.findAll();
+
+        List<RecipeDocument> documents = allRecipes.stream()
+                .map(RecipeDocument::from) // 아까 만든 변환 메서드
                 .collect(Collectors.toList());
 
-        recipeRepository.bulkInsertRecipes(recipesToInsert);
-    }
-
-    /**
-     * 수집된 원본 DTO(RawRecipeDto)를 도메인 엔티티(Recipe)로 변환합니다.
-     * @param r 원본 데이터 DTO
-     * @return 가공된 Recipe 엔티티
-     */
-    private Recipe convertToEntity(RawRecipeDto r) {
-        return Recipe.builder()
-                .recipeName(r.getRCP_NM())
-                .recipeThumbnail(r.getATT_FILE_NO_MK())
-                .ingredients(r.getRCP_PARTS_DTLS())
-                .manualSteps(extractStructuredManual(r))
-                .build();
-    }
-
-    /**
-     * 비정형화된 API 원본 텍스트에서 조리 단계별 설명과 이미지를 추출합니다.
-     * 정규식을 사용하여 텍스트 끝의 불필요한 문자를 정제합니다.
-     * @param recipe 원본 데이터 DTO
-     * @return 정제된 조리 단계 리스트 (ManualStep)
-     */
-    private List<Recipe.ManualStep> extractStructuredManual(RawRecipeDto recipe) {
-        List<Recipe.ManualStep> steps = new ArrayList<>();
-        Pattern cleanupPattern = Pattern.compile("(?<=\\.)[a-z]$", Pattern.CASE_INSENSITIVE);
-
-        for (int step = 1; step <= 20; step++) {
-            String stepText = recipe.getManualTextByStep(step);
-            String stepImg = recipe.getManualImgByStep(step);
-
-            if (stepText == null || stepText.trim().isEmpty()) break;
-
-            String cleanedText = cleanupPattern.matcher(stepText.trim()).replaceAll("").trim();
-
-            steps.add(new Recipe.ManualStep(step, cleanedText, stepImg != null ? stepImg.trim() : ""));
-        }
-        return steps;
-    }
-
-    /**
-     * 식품안전나라 Open API를 호출하여 원본 레시피 데이터를 가져옵니다.
-     * 환경 설정 파일에서 인증 정보를 읽어오며, Jackson을 사용하여 결과를 DTO로 매핑합니다.
-     * 추후, api 통신만을 담당하는 Client를 만들 예정입니다.
-     * @return 수집된 RawRecipeDto 리스트
-     */
-    private List<RawRecipeDto> fetchRecipesFromApi(){
-        String authKey = env.getProperty("AUTH_KEY");
-        String serviceId = env.getProperty("SERVICE_ID");
-        String dataType = env.getProperty("DATA_TYPE");
-        Integer startIdx = 1;
-        Integer endIdx = 100;
-        String uri = String.format("http://openapi.foodsafetykorea.go.kr/api/%s/%s/%s/%d/%d",
-                authKey, serviceId, dataType, startIdx, endIdx);
-        try{
-            Map<String, Object> response = restTemplate.getForObject(uri, Map.class);
-
-            if(response != null && response.containsKey("COOKRCP01")){
-                Map<String, Object> cookRecipe = (Map<String, Object>) response.get("COOKRCP01");
-                List<Map<String, Object>> rowList = (List<Map<String, Object>>) cookRecipe.get("row");
-
-                ObjectMapper mapper = new ObjectMapper();
-                return rowList.stream()
-                        .map(row -> mapper.convertValue(row, RawRecipeDto.class))
-                        .collect(Collectors.toList());
-            }
-        } catch(Exception e){
-            log.error("레시피 API 호출 중 오류 발생 : ", e.getMessage());
-        }
-
-        return new ArrayList<>();
-
-
+        esRecipeSearchRepository.saveAll(documents);
     }
 }

--- a/src/main/java/com/healthforu/config/RecipeDataInitializer.java
+++ b/src/main/java/com/healthforu/config/RecipeDataInitializer.java
@@ -18,11 +18,11 @@ import java.util.stream.Collectors;
 public class RecipeDataInitializer implements CommandLineRunner {
 
     private final RecipeRepository mongoRecipeRepository;
-    private final RecipeSearchRepository esRecipeSearchRepository;
+    private final RecipeSearchRepository recipeSearchRepository;
 
     @Override
     public void run(String... args) throws Exception {
-        if(esRecipeSearchRepository.count() > 0){
+        if(recipeSearchRepository.count() > 0){
             log.info("Elasticsearch에 이미 데이터가 존재합니다. 마이그레이션을 건너뜁니다.");
             return;
         }
@@ -32,9 +32,9 @@ public class RecipeDataInitializer implements CommandLineRunner {
         List<Recipe> allRecipes = mongoRecipeRepository.findAll();
 
         List<RecipeDocument> documents = allRecipes.stream()
-                .map(RecipeDocument::from) // 아까 만든 변환 메서드
+                .map(RecipeDocument::from)
                 .collect(Collectors.toList());
 
-        esRecipeSearchRepository.saveAll(documents);
+        recipeSearchRepository.saveAll(documents);
     }
 }

--- a/src/main/java/com/healthforu/disease/controller/DiseaseController.java
+++ b/src/main/java/com/healthforu/disease/controller/DiseaseController.java
@@ -3,6 +3,7 @@ package com.healthforu.disease.controller;
 import com.healthforu.category.dto.CategoryWithDiseasesResponse;
 import com.healthforu.disease.dto.DiseaseResponse;
 import com.healthforu.disease.service.DiseaseService;
+import com.healthforu.disease.service.elasticsearch.DiseaseSearchService;
 import lombok.RequiredArgsConstructor;
 import org.bson.types.ObjectId;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,7 @@ import java.util.List;
 public class DiseaseController {
 
     private final DiseaseService diseaseService;
+    private final DiseaseSearchService diseaseSearchService;
 
     @GetMapping("/{diseaseId}")
     public ResponseEntity<DiseaseResponse> getDiseaseDetail(@PathVariable("diseaseId") ObjectId diseaseId){
@@ -28,7 +30,7 @@ public class DiseaseController {
     public ResponseEntity<List<CategoryWithDiseasesResponse>> getDiseasesByCategories(
             @RequestParam(value = "keyword", required = false) String keyword){
 
-        return ResponseEntity.ok(diseaseService.searchDiseases(keyword));
+        return ResponseEntity.ok(diseaseSearchService.searchDiseases(keyword));
     }
 
 }

--- a/src/main/java/com/healthforu/disease/domain/DiseaseDocument.java
+++ b/src/main/java/com/healthforu/disease/domain/DiseaseDocument.java
@@ -1,0 +1,14 @@
+package com.healthforu.disease.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.elasticsearch.annotations.Document;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(indexName = "diseases")
+public class DiseaseDocument {
+
+}

--- a/src/main/java/com/healthforu/disease/domain/DiseaseDocument.java
+++ b/src/main/java/com/healthforu/disease/domain/DiseaseDocument.java
@@ -1,14 +1,38 @@
 package com.healthforu.disease.domain;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
 
+@Builder
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Document(indexName = "diseases")
 public class DiseaseDocument {
 
+    @Id
+    private String id;
+
+    @Field(type = FieldType.Text, analyzer = "nori")
+    private String diseaseName;
+
+    @Field(type = FieldType.Text, analyzer = "nori")
+    private String caution;
+
+    private String categoryId;
+
+    public static DiseaseDocument from(Disease disease){
+        return DiseaseDocument.builder()
+                .id(disease.getId().toHexString())
+                .diseaseName(disease.getDiseaseName())
+                .caution(disease.getCaution())
+                .categoryId(disease.getCategoryId() != null ? disease.getCategoryId().toHexString() : null)
+                .build();
+    }
 }

--- a/src/main/java/com/healthforu/disease/repository/elasticsearch/DiseaseSearchRepository.java
+++ b/src/main/java/com/healthforu/disease/repository/elasticsearch/DiseaseSearchRepository.java
@@ -1,0 +1,4 @@
+package com.healthforu.disease.repository.elasticsearch;
+
+public interface DiseaseSearchRepository {
+}

--- a/src/main/java/com/healthforu/disease/repository/elasticsearch/DiseaseSearchRepository.java
+++ b/src/main/java/com/healthforu/disease/repository/elasticsearch/DiseaseSearchRepository.java
@@ -1,4 +1,7 @@
 package com.healthforu.disease.repository.elasticsearch;
 
-public interface DiseaseSearchRepository {
+import com.healthforu.disease.domain.DiseaseDocument;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface DiseaseSearchRepository extends ElasticsearchRepository<DiseaseDocument, String> {
 }

--- a/src/main/java/com/healthforu/disease/service/elasticsearch/DiseaseSearchService.java
+++ b/src/main/java/com/healthforu/disease/service/elasticsearch/DiseaseSearchService.java
@@ -1,0 +1,10 @@
+package com.healthforu.disease.service.elasticsearch;
+
+import com.healthforu.category.dto.CategoryWithDiseasesResponse;
+
+import java.util.List;
+
+public interface DiseaseSearchService {
+
+    List<CategoryWithDiseasesResponse> searchDiseases(String keyword);
+}

--- a/src/main/java/com/healthforu/disease/service/elasticsearch/impl/DiseaseSearchServiceImpl.java
+++ b/src/main/java/com/healthforu/disease/service/elasticsearch/impl/DiseaseSearchServiceImpl.java
@@ -1,0 +1,71 @@
+package com.healthforu.disease.service.elasticsearch.impl;
+
+import com.healthforu.category.dto.CategoryResponse;
+import com.healthforu.category.dto.CategoryWithDiseasesResponse;
+import com.healthforu.category.service.CategoryService;
+import com.healthforu.disease.domain.DiseaseDocument;
+import com.healthforu.disease.dto.DiseaseResponse;
+import com.healthforu.disease.service.elasticsearch.DiseaseSearchService;
+import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class DiseaseSearchServiceImpl implements DiseaseSearchService {
+
+    private final ElasticsearchOperations elasticsearchOperations;
+    private final CategoryService categoryService;
+
+    @Override
+    public List<CategoryWithDiseasesResponse> searchDiseases(String keyword) {
+        List<CategoryResponse> categories = categoryService.getAllCategories();
+
+        return categories.stream().map(cat -> {
+                    List<DiseaseResponse> diseases;
+
+                    NativeQuery query = NativeQuery.builder()
+                            .withQuery(q -> q.bool(b -> {
+                                b.must(m -> m.term(t -> t.field("categoryId").value(cat.id().toHexString())));
+
+                                if (keyword == null || keyword.isBlank()) {
+                                    b.must(m -> m.matchAll(ma -> ma));
+                                } else {
+                                    b.must(m -> m.match(ma -> ma.field("diseaseName").query(keyword)));
+                                }
+                                return b;
+                            }))
+                            .build();
+
+                    SearchHits<DiseaseDocument> searchHits = elasticsearchOperations.search(query, DiseaseDocument.class);
+
+                    diseases = searchHits.getSearchHits().stream()
+                            .map(hit -> {
+                                DiseaseDocument doc = hit.getContent();
+                                return new DiseaseResponse(
+                                        doc.getId(),
+                                        doc.getDiseaseName(),
+                                        doc.getCaution(),
+                                        null,
+                                        new ObjectId(doc.getCategoryId())
+                                );
+                            })
+                            .toList();
+
+                    return new CategoryWithDiseasesResponse(
+                            cat.id().toHexString(),
+                            cat.categoryName(),
+                            cat.iconUrl(),
+                            diseases
+                    );
+                })
+                //  검색어가 있을 때는 결과가 비어있는 카테고리는 제외
+                .filter(res -> keyword == null || !res.diseases().isEmpty())
+                .toList();
+    }
+}

--- a/src/main/java/com/healthforu/recipe/controller/RecipeAdminController.java
+++ b/src/main/java/com/healthforu/recipe/controller/RecipeAdminController.java
@@ -1,6 +1,6 @@
 package com.healthforu.recipe.controller;
 
-import com.healthforu.config.RecipeDataInitializer;
+import com.healthforu.config.MongoDataInitializer;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,11 +11,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class RecipeAdminController {
 
-    private final RecipeDataInitializer recipeDataInitializer;
+    private final MongoDataInitializer mongoDataInitializer;
 
     @PostMapping("/import")
     public String initData() {
-        recipeDataInitializer.importRecipesFromExternalApi();
+        mongoDataInitializer.importRecipesFromExternalApi();
 
         return "Recipe data import started!";
     }

--- a/src/main/java/com/healthforu/recipe/controller/RecipeController.java
+++ b/src/main/java/com/healthforu/recipe/controller/RecipeController.java
@@ -2,6 +2,7 @@ package com.healthforu.recipe.controller;
 
 import com.healthforu.recipe.dto.RecipeResponse;
 import com.healthforu.recipe.service.RecipeService;
+import com.healthforu.recipe.service.elasticsearch.RecipeSearchService;
 import lombok.RequiredArgsConstructor;
 import org.bson.types.ObjectId;
 import org.springframework.data.domain.Page;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 public class RecipeController {
 
     private final RecipeService recipeService;
+    private final RecipeSearchService recipeSearchService;
 
     @GetMapping("/{recipeId}")
     public ResponseEntity<RecipeResponse> getRecipeDetail(
@@ -31,6 +33,6 @@ public class RecipeController {
             @RequestParam(value = "keyword", required = false) String keyword,
             Pageable pageable) {
 
-        return ResponseEntity.ok(recipeService.getAllRecipes(diseaseId, pageable, keyword));
+        return ResponseEntity.ok(recipeSearchService.searchRecipes(keyword, diseaseId, pageable));
     }
 }

--- a/src/main/java/com/healthforu/recipe/domain/RecipeDocument.java
+++ b/src/main/java/com/healthforu/recipe/domain/RecipeDocument.java
@@ -1,0 +1,39 @@
+package com.healthforu.recipe.domain;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Setting;
+
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Document(indexName = "recipes")
+@Setting(settingPath = "elasticsearch/settings.json")
+public class RecipeDocument {
+
+    @Id
+    private String id;
+
+    @Field(type = FieldType.Text, analyzer = "nori", searchAnalyzer = "nori")
+    private String recipeName;
+
+    @Field(type = FieldType.Text, analyzer = "nori")
+    private String ingredients;
+
+    private String recipeThumbnail;
+
+    public static RecipeDocument from(Recipe recipe) {
+        return RecipeDocument.builder()
+                .id(recipe.getId().toHexString())
+                .recipeName(recipe.getRecipeName())
+                .ingredients(recipe.getIngredients())
+                .recipeThumbnail(recipe.getRecipeThumbnail())
+                .build();
+    }
+
+}

--- a/src/main/java/com/healthforu/recipe/repository/elasticsearch/RecipeSearchRepository.java
+++ b/src/main/java/com/healthforu/recipe/repository/elasticsearch/RecipeSearchRepository.java
@@ -1,0 +1,7 @@
+package com.healthforu.recipe.repository.elasticsearch;
+
+import com.healthforu.recipe.domain.RecipeDocument;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface RecipeSearchRepository extends ElasticsearchRepository<RecipeDocument, String> {
+}

--- a/src/main/java/com/healthforu/recipe/service/elasticsearch/RecipeSearchService.java
+++ b/src/main/java/com/healthforu/recipe/service/elasticsearch/RecipeSearchService.java
@@ -1,0 +1,17 @@
+package com.healthforu.recipe.service.elasticsearch;
+
+import com.healthforu.recipe.dto.RecipeResponse;
+import org.bson.types.ObjectId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+
+public interface RecipeSearchService {
+
+    /**
+     * 특정 질환자가 피해야 할 재료(Caution)를 제외하고 검색합니다.
+     * (이름에 가중치를 부여하고, Nori 분석기를 통해 검색합니다.)
+     */
+    Page<RecipeResponse> searchRecipes(String keyword, ObjectId diseaseId, Pageable pageable);
+
+}

--- a/src/main/java/com/healthforu/recipe/service/elasticsearch/impl/RecipeSearchServiceImpl.java
+++ b/src/main/java/com/healthforu/recipe/service/elasticsearch/impl/RecipeSearchServiceImpl.java
@@ -1,0 +1,104 @@
+package com.healthforu.recipe.service.elasticsearch.impl;
+
+import com.healthforu.disease.dto.DiseaseResponse;
+import com.healthforu.disease.service.DiseaseService;
+import com.healthforu.recipe.domain.RecipeDocument;
+import com.healthforu.recipe.dto.RecipeResponse;
+import com.healthforu.recipe.service.elasticsearch.RecipeSearchService;
+import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.stereotype.Service;
+import com.healthforu.common.exception.custom.DiseaseNotFoundException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+public class RecipeSearchServiceImpl implements RecipeSearchService {
+
+    private final ElasticsearchOperations elasticsearchOperations;
+    private final DiseaseService diseaseService;
+
+    /**
+     * 키워드와 질환 정보를 바탕으로 최적화된 레시피 목록을 검색합니다.
+     * <p>
+         * 1. 검색 키워드가 없는 경우: 특정 질환의 주의 식품(caution)이 포함된 레시피를
+         * 전체 목록에서 제외하여 안전한 레시피만 반환합니다.
+         * 2. 검색 키워드가 있는 경우: 이름(가중치 5.0)과 재료(가중치 1.0)를 기준으로 검색하며,
+         * 주의 식품 포함 여부와 상관없이 연관된 레시피를 모두 반환하되 주의 표시(isCaution)를 추가합니다.
+     * </p>
+     *
+     * @param keyword        사용자가 입력한 검색어 (null 가능)
+     * @param diseaseId      사용자가 선택한 질환 식별자 (주의 식품 조회용)
+     * @param pageable       페이지네이션 정보 (페이지 번호, 사이즈 등)
+     * @return               검색 결과 및 주의 식품 포함 여부가 담긴 레시피 페이지 객체
+     * @throws DiseaseNotFoundException 유효하지 않은 질병 ID일 경우 발생
+     */
+    @Override
+    public Page<RecipeResponse> searchRecipes(String keyword, ObjectId diseaseId, Pageable pageable) {
+
+        DiseaseResponse diseaseResponse = diseaseService.getDisease(diseaseId);
+        String caution = (diseaseResponse != null) ? diseaseResponse.caution() : "";
+
+        List<String> cautionList = (caution != null && !caution.isBlank())
+                ? Arrays.stream(caution.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList()
+                : Collections.emptyList();
+
+        // 키워드가 없으면 전체 조회, 있으면 가중치 검색
+        NativeQuery query = NativeQuery.builder()
+                .withQuery(q -> q.bool(b -> {
+                    if (keyword == null || keyword.isBlank()) {
+                        b.must(m -> m.matchAll(ma -> ma));
+
+                        for (String item : cautionList) {
+                            b.mustNot(mn -> mn.match(m -> m.field("ingredients").query(item)));
+                            b.mustNot(mn -> mn.match(m -> m.field("recipeName").query(item)));
+                        }
+                    } else {
+                        b.should(s -> s.match(m -> m.field("recipeName").query(keyword).boost(5.0f)));
+                        b.should(s -> s.match(m -> m.field("ingredients").query(keyword).boost(1.0f)));
+                        b.minimumShouldMatch("1");
+                    }
+                    return b;
+                }))
+                .withPageable(pageable)
+                .build();
+
+        SearchHits<RecipeDocument> searchHits = elasticsearchOperations.search(query, RecipeDocument.class);
+
+        // 레시피 데이터 포장
+        List<RecipeResponse> content = searchHits.getSearchHits().stream()
+                .map(hit -> {
+                    RecipeDocument doc = hit.getContent();
+
+                    boolean isCaution = cautionList.stream().anyMatch(c ->
+                            doc.getRecipeName().contains(c) || doc.getIngredients().contains(c));
+
+                    return new RecipeResponse(
+                            doc.getId(),
+                            doc.getRecipeName(),
+                            doc.getIngredients(),
+                            null,
+                            doc.getRecipeThumbnail(),
+                            isCaution,
+                            false
+                    );
+                })
+                .toList();
+
+        return new PageImpl<>(content, pageable, searchHits.getTotalHits());
+    }
+
+}

--- a/src/main/resources/elasticsearch/settings.json
+++ b/src/main/resources/elasticsearch/settings.json
@@ -1,0 +1,10 @@
+{
+  "analysis": {
+    "analyzer": {
+      "nori": {
+        "type": "custom",
+        "tokenizer": "nori_tokenizer"
+      }
+    }
+  }
+}

--- a/src/test/java/com/healthforu/common/config/MongoDataInitializerTest.java
+++ b/src/test/java/com/healthforu/common/config/MongoDataInitializerTest.java
@@ -1,6 +1,6 @@
 package com.healthforu.common.config;
 
-import com.healthforu.config.RecipeDataInitializer;
+import com.healthforu.config.MongoDataInitializer;
 import com.healthforu.recipe.domain.Recipe;
 import com.healthforu.recipe.repository.RecipeRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -22,10 +22,10 @@ import static org.mockito.Mockito.when;
 
 @SpringBootTest
 @Import(MongoTestConfig.class)
-class RecipeDataInitializerTest {
+class MongoDataInitializerTest {
 
     @Autowired
-    private RecipeDataInitializer recipeDataInitializer;
+    private MongoDataInitializer mongoDataInitializer;
 
     @Autowired
     private RecipeRepository recipeRepository;
@@ -51,7 +51,7 @@ class RecipeDataInitializerTest {
         when(restTemplate.getForObject(anyString(), eq(Map.class)))
                 .thenReturn(mockResponse);
 
-        recipeDataInitializer.importRecipesFromExternalApi();
+        mongoDataInitializer.importRecipesFromExternalApi();
 
         List<Recipe> savedRecipes = recipeRepository.findAll();
 


### PR DESCRIPTION
# 📝 개요
MongoDB Atlas에 저장된 질병 및 레시피 데이터를 Elasticsearch로 마이그레이션하고, `nori` 분석기를 활용한 질병 검색 및 레시피 주의 식품 매칭 시스템을 구축했습니다.

- **Source:** `feature/elastic-search`
- **Destination:** `dev`


# 🔗 관련 이슈
- #3 

---

# 💡 주요 변경 사항
- **Elasticsearch 인덱싱 및 분석기 설정**
    - `diseases`, `recipes` 인덱스 구축 및 `nori` 형태소 분석기 적용
    - `ElasticsearchConfig` 수정을 통한 환경별(Local, Docker) 유연한 연결 지원 (`@Value` 및 `replace` 로직 활용)
- **데이터 자동 마이그레이션 (Data Initializer)**
    - 서버 기동 시 MongoDB 데이터를 Elasticsearch로 자동 적재하는 `DiseaseDataInitializer`, `RecipeDataInitializer` 구현
    - 인덱스 존재 여부 체크를 통한 데이터 중복 적재 방지
- **질병-레시피 매칭 로직 (isCaution)**
    - 질병별 주의 재료(`caution`) 키워드를 추출하여 레시피 재료와 매칭하는 알고리즘 구현
    - 검색 결과 내 `isCaution` 필드 추가를 통한 사용자 맞춤형 정보 제공

---

# 🚀 주요 구현 API 목록
| API 명칭 | 메서드 | 엔드포인트 | 비고 |
| :--- | :---: | :--- | :--- |
| 질병 통합 검색 | `GET` | `/api/diseases?keyword={키워드}` | `nori` 분석기를 통한 형태소 단위 검색 지원 |
| 질병 맞춤 레시피 검색 | `GET` | `/api/recipes?diseaseId={id}` | 주의 재료 매칭(`isCaution`) 결과 포함 |

---

# ✅ 작업 체크리스트
- [x] Elasticsearch `nori` 형태소 분석기 적용 및 검색 테스트 완료
- [x] MongoDB Atlas -> Elasticsearch 데이터 마이그레이션 로직 검증 완료
- [x] 운영 환경 반영을 위한 ElasticsearchConfig 서비스 이름 기반 통신 로직 구현 (배포 후 최종 검증 예정)
- [x] 질병 키워드 검색 시 유연한 한글 검색 결과 확인
- [x] 레시피 검색 시 질병별 주의 재료에 따른 `isCaution` 플래그 정상 작동 확인