### PR TITLE
질병 엘라스틱서치 N+1 해결

### DIFF
--- a/src/main/java/com/healthforu/category/repository/CategoryRepository.java
+++ b/src/main/java/com/healthforu/category/repository/CategoryRepository.java
@@ -6,12 +6,10 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 
 public interface CategoryRepository extends MongoRepository<Category, ObjectId> {
 
     List<Category> findAll(Sort sort);
 
-    Optional<Category> findByCategorySlug(String slug);
 }

--- a/src/main/java/com/healthforu/disease/domain/DiseaseDocument.java
+++ b/src/main/java/com/healthforu/disease/domain/DiseaseDocument.java
@@ -10,6 +10,14 @@ import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 import org.springframework.data.elasticsearch.annotations.Setting;
 
+/**
+ * Elasticsearch의 'diseases' 인덱스와 매핑되는 도메인(Document) 클래스
+ * <p>
+ * 질환 검색 성능 향상을 위해 노리(nori) 형태소 분석기를 적용하여 질환명 및 주의사항을 인덱싱한다.
+ * DB(Elasticsearch) 조회를 위한 전용 엔티티이며, 클라이언트 응답 시에는 {@link com.healthforu.disease.dto.DiseaseResponse}로 변환되어 사용된다.
+ * (데이터베이스와 자바 스프링 코드를 이어주는 다리 역할!)
+ * </p>
+ */
 @Builder
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/healthforu/disease/service/elasticsearch/impl/DiseaseSearchServiceImpl.java
+++ b/src/main/java/com/healthforu/disease/service/elasticsearch/impl/DiseaseSearchServiceImpl.java
@@ -11,10 +11,15 @@ import lombok.RequiredArgsConstructor;
 import org.bson.types.ObjectId;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
 import org.springframework.data.elasticsearch.core.SearchHits;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
+import java.util.Map;
+
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -35,52 +40,64 @@ public class DiseaseSearchServiceImpl implements DiseaseSearchService {
      * 검색어가 존재할 경우, 결과가 비어있는 카테고리는 결과 목록에서 제외됩니다.
      */
     @Override
-    @CaptureSpan(value = "MongoDB-Disease-Query", type = "db", subtype = "mongodb", action = "query") // apm 에이전트가 시각화할 수 있도록 함
+    @CaptureSpan(value = "Elasticsearch-Disease-Query", type = "db", subtype = "elasticsearch", action = "query") // apm 에이전트가 시각화할 수 있도록 함
     public List<CategoryWithDiseasesResponse> searchDiseases(String keyword) {
+        // 일단 키워드 유무에 따라 한 번에 들고올 엘라스틱서치 쿼리를 결정
+        NativeQuery query = NativeQuery.builder() // 복잡한 객체의 생성과 조립을 별도의 빌더 객체로 캡슐화
+        // 특정 카테고리 ID와 일치하는 문서만 필터링 (Term Query)
+        .withQuery(q->q.bool(b->{ // QueryDSL 직접 정의. 복합 조건 걸기위한 bool 상자 열기
+            // 키워드 유무에 따른 동적 쿼리 처리
+            if(keyword==null || keyword.isBlank()){
+                b.must(m->m.matchAll(ma->ma));
+            } else {
+                b.must(m->m.match(ma->ma.field("diseaseName").query(keyword)));
+            }
+
+            return b;
+        }))
+        .withMaxResults(100)
+        .build();
+
+        // 매번 찌르던 N+1 문제를 해결하기 위해 엘라스틱 서치에서 한 번에 싹 다 조회해 옴
+        SearchHits<DiseaseDocument> searchHits = elasticsearchOperations.search(query, DiseaseDocument.class);
+        // 가져온 질병들을 카테고리 ID별로 그룹핑(Map구조로 변환하여 메모리 준비)
+        Map<String, List<DiseaseDocument>> diseaseMapByCategoryId = searchHits.getSearchHits().stream() // DiseaseDocument가 리스트로 감싸져있음
+                .map(SearchHit::getContent) // DiseaseDocument 하나 꺼냄
+                .collect(Collectors.groupingBy(DiseaseDocument::getCategoryId)); // 카테고리별로 그룹화해서 정리해둠
+        // 전체 카테고리 목록 들고옴
         List<CategoryResponse> categories = categoryService.getAllCategories();
 
-        return categories.stream().map(cat -> {
-                    List<DiseaseResponse> diseases;
+        // stream()으로 공장 컨베이어 벨트에 데이터가 하나씩 들어온다고 생각!
+        return categories.stream().map(cat->{
+            // 카테고리 아이디 string 변환
+            String catIdStr = cat.id().toHexString();
 
-                    NativeQuery query = NativeQuery.builder()
-                            // 특정 카테고리 ID와 일치하는 문서만 필터링 (Term Query)
-                            .withQuery(q -> q.bool(b -> {
-                                b.must(m -> m.term(t -> t.field("categoryId").value(cat.id().toHexString())));
+            // 엘라스틱 서치로 미리 뽑아온 현재 카테고리 ID에 맞는 질환 데이터가 있다면 들고오고, 없으면 비어있는 리스트 반환 (네트워크 통신 0초!)
+            List<DiseaseDocument> docs = diseaseMapByCategoryId.getOrDefault(catIdStr, Collections.emptyList());
+            List<DiseaseResponse> diseases = docs.stream()
+                    .map(doc -> new DiseaseResponse(
+                            doc.getId(),
+                            doc.getDiseaseName(),
+                            doc.getCaution(),
+                            null,
+                            new ObjectId(doc.getCategoryId())
+                    ))
+                    .toList();
 
-                                // 키워드 유무에 따른 동적 쿼리 처리
-                                if (keyword == null || keyword.isBlank()) {
-                                    b.must(m -> m.matchAll(ma -> ma));
-                                } else {
-                                    b.must(m -> m.match(ma -> ma.field("diseaseName").query(keyword)));
-                                }
-                                return b;
-                            }))
-                            .build();
+            // 매핑 공장 안에서 변형된 카테고리별 객체를 하나씩 벨트 위로 던져줌(내부 반환)
+            return new CategoryWithDiseasesResponse(
+                    cat.id().toHexString(),
+                    cat.categoryName(),
+                    cat.iconUrl(),
+                    diseases
+            );
 
-                    SearchHits<DiseaseDocument> searchHits = elasticsearchOperations.search(query, DiseaseDocument.class);
+        })
+        //  검색어가 있을 때는 결과가 비어있는 카테고리는 제외(조건 필터링 후 차곡차곡 담아둔다)
+        .filter(res -> keyword==null || !res.diseases().isEmpty())
+        // 최종 반환
+        .toList();
 
-                    diseases = searchHits.getSearchHits().stream()
-                            .map(hit -> {
-                                DiseaseDocument doc = hit.getContent();
-                                return new DiseaseResponse(
-                                        doc.getId(),
-                                        doc.getDiseaseName(),
-                                        doc.getCaution(),
-                                        null,
-                                        new ObjectId(doc.getCategoryId())
-                                );
-                            })
-                            .toList();
 
-                    return new CategoryWithDiseasesResponse(
-                            cat.id().toHexString(),
-                            cat.categoryName(),
-                            cat.iconUrl(),
-                            diseases
-                    );
-                })
-                //  검색어가 있을 때는 결과가 비어있는 카테고리는 제외
-                .filter(res -> keyword == null || !res.diseases().isEmpty())
-                .toList();
     }
 }

--- a/src/main/java/com/healthforu/recipe/service/elasticsearch/impl/RecipeSearchServiceImpl.java
+++ b/src/main/java/com/healthforu/recipe/service/elasticsearch/impl/RecipeSearchServiceImpl.java
@@ -45,7 +45,7 @@ public class RecipeSearchServiceImpl implements RecipeSearchService {
      * @throws DiseaseNotFoundException 유효하지 않은 질병 ID일 경우 발생
      */
     @Override
-    @CaptureSpan(value = "MongoDB-Disease-Query", type = "db", subtype = "mongodb", action = "query") // apm 에이전트가 시각화할 수 있도록 함
+    @CaptureSpan(value = "Elasticsearch-Recipe-Query", type = "db", subtype = "mongodb", action = "query") // apm 에이전트가 시각화할 수 있도록 함
     public Page<RecipeResponse> searchRecipes(String keyword, ObjectId diseaseId, Pageable pageable) {
 
         DiseaseResponse diseaseResponse = diseaseService.getDisease(diseaseId);


### PR DESCRIPTION
## 📌 개요
- **이슈 번호**: #6 
- **핵심 작업**: 질환(Disease) 조회 API의 카테고리별 반복 호출(N+1 문제)로 인한 주요 병목 현상을 Elasticsearch 복합 쿼리(`bool`) 및 Java Stream 메모리 그룹핑 기술을 도입하여 획딩한 성능 최적화 작업.

---

## 🛠️ 주요 변경 사항

### 1. Elasticsearch N+1 쿼리 병목 해결
- **기존 구조**: 카테고리 전체 목록을 들고 온 후, Java Loop를 돌며 카테고리 ID당 1번씩 Elasticsearch에 개별적으로 쿼리를 날림 -> **카테고리 수(N) + 1번의 네트워크 통신 발생 (평균 1.5초~5초 대기)**
- **변경 구조**: 
  - 키워드 유무에 따른 동적 `NativeQuery`를 빌더로 조립하여 단 **1번의 쿼리**로 조건에 맞는 전체 질병 문서를 통째로 가져옴.
  - `Collectors.groupingBy`를 활용해 조회 데이터를 `Map<String, List<DiseaseDocument>>` 구조로 메모리에서 카테고리별로 그룹화함.
  - 이후 카테고리 순회 시 추가적인 DB 통신 없이 맵에서 데이터를 즉시 꺼내 쓰도록 변경하여 네트워크 I/O 비용 최소화.

### 2. 가독성 및 유지보수성 향상
- 복잡한 Elasticsearch QueryDSL 조립부의 가독성을 높이기 위해 람다식 규칙(`ma -> ma`) 및 빌더 패턴에 상세한 한글 주석 및 Javadocs 추가.
- APM(Elastic APM) 시각화를 위한 핀포인트 애노테이션(`@CaptureSpan`) 적용 유지.
---
## 🧪 테스트 및 검증 계획 (Test & Monitor Plan)
- [x] 메인 브랜치 머지 및 운영 서버 배포 후, Kibana APM 대시보드를 통해 기존 N+1 쿼리 트레이스(Span)가 단일 `Elasticsearch-Disease-Query`로 정상 통합되었는지 트래픽 모니터링 예정.