### PR TITLE
Recipe 검색 로직 수정 이유(searchRecipes 메소드)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ src/main/resources/application-dev.properties
 src/main/resources/application-prod.properties
 src/main/resources/application-test.properties
 src/test/resources/application.properties
+src/main/resources/apmserver/

--- a/src/main/java/com/healthforu/config/RecipeDataInitializer.java
+++ b/src/main/java/com/healthforu/config/RecipeDataInitializer.java
@@ -21,7 +21,7 @@ public class RecipeDataInitializer implements CommandLineRunner {
     private final RecipeSearchRepository recipeSearchRepository;
 
     @Override
-    public void run(String... args) throws Exception {
+    public void run(String... args) {
         if(recipeSearchRepository.count() > 0){
             log.info("Elasticsearch에 이미 데이터가 존재합니다. 마이그레이션을 건너뜁니다.");
             return;

--- a/src/main/java/com/healthforu/recipe/controller/RecipeController.java
+++ b/src/main/java/com/healthforu/recipe/controller/RecipeController.java
@@ -31,8 +31,9 @@ public class RecipeController {
     public ResponseEntity<Page<RecipeResponse>> getAllRecipes(
             @RequestParam("diseaseId") ObjectId diseaseId,
             @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(required = false, defaultValue = "") String caution,
             Pageable pageable) {
 
-        return ResponseEntity.ok(recipeSearchService.searchRecipes(keyword, diseaseId, pageable));
+        return ResponseEntity.ok(recipeSearchService.searchRecipes(keyword, diseaseId, caution, pageable));
     }
 }

--- a/src/main/java/com/healthforu/recipe/service/elasticsearch/RecipeSearchService.java
+++ b/src/main/java/com/healthforu/recipe/service/elasticsearch/RecipeSearchService.java
@@ -12,6 +12,6 @@ public interface RecipeSearchService {
      * 특정 질환자가 피해야 할 재료(Caution)를 제외하고 검색합니다.
      * (이름에 가중치를 부여하고, Nori 분석기를 통해 검색합니다.)
      */
-    Page<RecipeResponse> searchRecipes(String keyword, ObjectId diseaseId, Pageable pageable);
+    Page<RecipeResponse> searchRecipes(String keyword, ObjectId diseaseId, String caution, Pageable pageable);
 
 }

--- a/src/main/java/com/healthforu/recipe/service/elasticsearch/impl/RecipeSearchServiceImpl.java
+++ b/src/main/java/com/healthforu/recipe/service/elasticsearch/impl/RecipeSearchServiceImpl.java
@@ -45,7 +45,7 @@ public class RecipeSearchServiceImpl implements RecipeSearchService {
      * @throws DiseaseNotFoundException 유효하지 않은 질병 ID일 경우 발생
      */
     @Override
-    @CaptureSpan(value = "Elasticsearch-Recipe-Query", type = "db", subtype = "mongodb", action = "query") // apm 에이전트가 시각화할 수 있도록 함
+    @CaptureSpan(value = "Elasticsearch-Recipe-Query", type = "db", subtype = "elasticsearch", action = "query") // apm 에이전트가 시각화할 수 있도록 함
     public Page<RecipeResponse> searchRecipes(String keyword, ObjectId diseaseId, Pageable pageable) {
 
         DiseaseResponse diseaseResponse = diseaseService.getDisease(diseaseId);
@@ -80,18 +80,22 @@ public class RecipeSearchServiceImpl implements RecipeSearchService {
 
         SearchHits<RecipeDocument> searchHits = elasticsearchOperations.search(query, RecipeDocument.class);
 
+        // 키워드 유무 확인
+        boolean hasKeyword = (keyword != null && !keyword.isBlank());
+
         // 레시피 데이터 포장
         List<RecipeResponse> content = searchHits.getSearchHits().stream()
                 .map(hit -> {
                     RecipeDocument doc = hit.getContent();
 
-                    boolean isCaution = cautionList.stream().anyMatch(c ->
+                    // 키워드가 있을 때만 검색(검색어가 있을 때는, 주의 식품 포함 여부와 상관없이 연관된 레시피를 모두 반환해야 함)
+                    boolean isCaution = hasKeyword && cautionList.stream().anyMatch(c ->
                             doc.getRecipeName().contains(c) || doc.getIngredients().contains(c));
 
                     return new RecipeResponse(
                             doc.getId(),
                             doc.getRecipeName(),
-                            doc.getIngredients(),
+                            null,
                             null,
                             doc.getRecipeThumbnail(),
                             isCaution,

--- a/src/main/java/com/healthforu/recipe/service/elasticsearch/impl/RecipeSearchServiceImpl.java
+++ b/src/main/java/com/healthforu/recipe/service/elasticsearch/impl/RecipeSearchServiceImpl.java
@@ -30,28 +30,23 @@ public class RecipeSearchServiceImpl implements RecipeSearchService {
     private final DiseaseService diseaseService;
 
     /**
-     * 키워드와 질환 정보를 바탕으로 최적화된 레시피 목록을 검색합니다.
+     * 검색 키워드와 프론트엔드로부터 전달받은 주의 식품(caution) 리스트를 바탕으로 최적화된 레시피 목록을 검색합니다.
      * <p>
-         * 1. 검색 키워드가 없는 경우: 특정 질환의 주의 식품(caution)이 포함된 레시피를
-         * 전체 목록에서 제외하여 안전한 레시피만 반환합니다.
-         * 2. 검색 키워드가 있는 경우: 이름(가중치 5.0)과 재료(가중치 1.0)를 기준으로 검색하며,
-         * 주의 식품 포함 여부와 상관없이 연관된 레시피를 모두 반환하되 주의 표시(isCaution)를 추가합니다.
+     * 1. 검색 키워드가 없는 경우 (전체 조회): 전달받은 주의 식품 목록(caution)이 이름이나 재료에 포함된 레시피를
+     *    Elasticsearch 쿼리 조건에서 원천 제외(mustNot)하여 안전한 레시피만 반환합니다.
+     * 2. 검색 키워드가 있는 경우 (키워드 검색): 이름(가중치 5.0)과 재료(가중치 1.0)를 기준으로 쿼리하되,
+     *    주의 식품 포함 여부와 상관없이 검색어와 연관된 레시피를 모두 반환하며, 결과에서 해당 주의 식품 포함 여부(isCaution)를 true로 표시합니다.
      * </p>
      *
-     * @param keyword        사용자가 입력한 검색어 (null 가능)
-     * @param diseaseId      사용자가 선택한 질환 식별자 (주의 식품 조회용)
-     * @param pageable       페이지네이션 정보 (페이지 번호, 사이즈 등)
-     * @return               검색 결과 및 주의 식품 포함 여부가 담긴 레시피 페이지 객체
-     * @throws DiseaseNotFoundException 유효하지 않은 질병 ID일 경우 발생
+     * @param keyword        사용자가 입력한 레시피 검색어 (null 또는 공백 가능)
+     * @param diseaseId      사용자가 선택한 질환 식별자 (필요 시 확장용 ObjectId)
+     * @param caution        프론트엔드에서 콤마(,)로 구분하여 전달한 주의 식품 명칭 문자열 (null 또는 공백 가능)
+     * @param pageable       페이지네이션 정보 (페이지 번호, 페이지 크기, 정렬 등)
+     * @return               주의 식품 필터링 또는 주의 표시(isCaution)가 반영된 레시피 페이지(Page) 객체
      */
-    // TODO : 프론트엔드와 협업하는 파라미터 패싱 방식 적용
     @Override
     @CaptureSpan(value = "Elasticsearch-Recipe-Query", type = "db", subtype = "elasticsearch", action = "query") // apm 에이전트가 시각화할 수 있도록 함
     public Page<RecipeResponse> searchRecipes(String keyword, ObjectId diseaseId, String caution, Pageable pageable) {
-
-//        DiseaseResponse diseaseResponse = diseaseService.getDisease(diseaseId);
-//        String caution = (diseaseResponse != null) ? diseaseResponse.caution() : "";
-
         List<String> cautionList = (caution != null && !caution.isBlank())
                 ? Arrays.stream(caution.split(","))
                 .map(String::trim)

--- a/src/main/java/com/healthforu/recipe/service/elasticsearch/impl/RecipeSearchServiceImpl.java
+++ b/src/main/java/com/healthforu/recipe/service/elasticsearch/impl/RecipeSearchServiceImpl.java
@@ -44,12 +44,13 @@ public class RecipeSearchServiceImpl implements RecipeSearchService {
      * @return               검색 결과 및 주의 식품 포함 여부가 담긴 레시피 페이지 객체
      * @throws DiseaseNotFoundException 유효하지 않은 질병 ID일 경우 발생
      */
+    // TODO : 프론트엔드와 협업하는 파라미터 패싱 방식 적용
     @Override
     @CaptureSpan(value = "Elasticsearch-Recipe-Query", type = "db", subtype = "elasticsearch", action = "query") // apm 에이전트가 시각화할 수 있도록 함
-    public Page<RecipeResponse> searchRecipes(String keyword, ObjectId diseaseId, Pageable pageable) {
+    public Page<RecipeResponse> searchRecipes(String keyword, ObjectId diseaseId, String caution, Pageable pageable) {
 
-        DiseaseResponse diseaseResponse = diseaseService.getDisease(diseaseId);
-        String caution = (diseaseResponse != null) ? diseaseResponse.caution() : "";
+//        DiseaseResponse diseaseResponse = diseaseService.getDisease(diseaseId);
+//        String caution = (diseaseResponse != null) ? diseaseResponse.caution() : "";
 
         List<String> cautionList = (caution != null && !caution.isBlank())
                 ? Arrays.stream(caution.split(","))

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 spring.application.name=health-service
-spring.profiles.active=prod
+spring.profiles.active=dev

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 spring.application.name=health-service
-spring.profiles.active=dev
+spring.profiles.active=prod


### PR DESCRIPTION
- **기존 문제점** 
  - 특정 질병 페이지에서 레시피를 검색할 때마다, 백엔드 내부에서 관련 주의 식품을 찾기 위해 `diseaseService`(DB 조회)를 불필요하게 매번 반복 호출하고 있었음.
  - 이로 인해 검색 요청 시마다 메인 검색 엔진 외에 추가적인 internal DB 조회가 발생하여 서버와 데이터베이스에 부하를 주게 됨.

- **개선 방향**
  - 프론트엔드 단에서 이미 보유하고 있는 주의 식품(`caution`) 데이터를 파라미터로 직접 넘겨받도록 구조를 변경.
  - 결과적으로 `diseaseService` 및 관련 DB의 불필요한 중복 호출을 완전히 제거하여 검색 API의 효율성을 높였음.

---

## 개선 결과 및 달라진 점

### 1. 인프라 부하 감소 및 불필요한 서비스 호출 제거
- 육안상 전체 응답 속도 차이는 미비할 수 있으나, 매 검색마다 내부적으로 일어났던 `diseaseService` 탐색 과정을 생략함으로써 서버 리소스 낭비를 줄이고 부담을 줄였음.

### 2. APM 모니터링 메타데이터 최적화
- 기존에 Elasticsearch 쿼리 트레이스가 APM 상에서 `mongodb` 타입으로 오분류되어 수집되던 문제 수정.
- `@CaptureSpan` 커스텀 설정을 통해 이제는 정확히 `elasticsearch` 인프라 쿼리로 분류 및 실시간 추적이 가능하도록 모니터링 환경을 정교화함.

---

## 스크린샷 비교

### 바뀌기 전
<img width="1058" height="451" alt="image" src="https://github.com/user-attachments/assets/db97a2e5-6579-4107-8545-0b02635653e6" />
<img width="1633" height="311" alt="image" src="https://github.com/user-attachments/assets/9f23bbaf-7839-4962-a8a8-2f5cd8ae202c" />

### 바뀐 후
<img width="1027" height="439" alt="image" src="https://github.com/user-attachments/assets/e4d6de7a-6f36-4e3b-b2a9-20ad43d6dc86" />
<img width="1608" height="324" alt="image" src="https://github.com/user-attachments/assets/5d2eb905-6393-4bb1-98bf-39ff044069b4" />